### PR TITLE
xiqnetwrapper: Add an implementation of XiQNetWrapper::protobufToByte…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ include(GNUInstallDirs)
 #Find dependecies
 find_package(Qt5 COMPONENTS Core Network CONFIG REQUIRED)
 find_package(Protobuf REQUIRED)
+find_package(zeraprotobuf REQUIRED)
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(Systemd REQUIRED libsystemd)
@@ -58,6 +59,7 @@ target_link_libraries(xiqnet
     Qt5::Core
     Qt5::Network
     ${Protobuf_LIBRARIES}   
+    VeinMeta::zeraprotobuf
     )
 
 

--- a/xiqnetwrapper.cpp
+++ b/xiqnetwrapper.cpp
@@ -1,0 +1,7 @@
+#include "xiqnetwrapper.h"
+#include <netmessages.pb.h>
+
+QByteArray XiQNetWrapper::protobufToByteArray(const google::protobuf::Message &t_protobufMessage)
+{
+  return QByteArray(t_protobufMessage.SerializeAsString().c_str(), t_protobufMessage.ByteSizeLong());
+}

--- a/xiqnetwrapper.h
+++ b/xiqnetwrapper.h
@@ -34,7 +34,7 @@ public:
    * @param t_protobufMessage
    * @return
    */
-  virtual QByteArray protobufToByteArray(const google::protobuf::Message &t_protobufMessage) =0;
+  virtual QByteArray protobufToByteArray(const google::protobuf::Message &t_protobufMessage);
 };
 
 #endif // PROTOWRAPPER_H


### PR DESCRIPTION
…Array

Looking through the code in all the users of xiqnet it seems ALL implement
protobufToByteArray identically. So offer the common as basic implementation.

* In case we find out that there is a client implementing protobufToByteArray
  differently it is free to override.
* Without further changes in client's code simply nothing changes

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>